### PR TITLE
Moved Event and bar headers outside el sections so now we can empty the ...

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -31,14 +31,17 @@
 }
 
 #main {
+  position: relative;
   float: left;
   width: 45%;
   text-align: center;
   border: 1px solid black;
+  margin-top: 0px;
 
 }
 
 #bar-results {
+position: relative;
 float: right;
 width: 45%;
 text-align: center;
@@ -48,4 +51,18 @@ border: 1px solid black;
 
 .single-view {
   background-color: slategray;
+}
+
+#bars-nearby {
+  position: relative;
+  float: right;
+  text-align: center;
+  margin-right: 20%;
+}
+
+#events-nearby {
+  position: relative;
+  float: left;
+  text-align: center;
+  margin-left: 18%;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -37,8 +37,12 @@
 
   <section id="nav"></section>
   
+  <h1 id="events-nearby">Events!</h1>
+  <h1 id="bars-nearby">Nearby Bars!</h1>
+
+
   <section id="main">
-    <h1>Shows!</h1>
+    <h1>Events!</h1>
   </section>
   
   <section id="bar-results">

--- a/public/js/views/barsView.js
+++ b/public/js/views/barsView.js
@@ -3,12 +3,13 @@ App.Views.Bars = Backbone.View.extend({
   el: "#bar-results",
 
   initialize: function() {
-    this.listenTo(this.collection, "reset", this.renderOne);
-    this.listenTo(this.collection, "add", this.renderOne);
-    this.renderAll();
+    this.listenTo(this.collection, "reset", this.renderAll);
+    this.listenTo(this.collection, "add", this.renderAll);
+    // this.renderAll();
   },
 
   renderAll: function() {
+    this.$el.empty();
     this.collection.each(this.renderOne, this);
   },
 

--- a/public/js/views/eventView.js
+++ b/public/js/views/eventView.js
@@ -28,7 +28,11 @@ App.Views.Event = Backbone.View.extend({
  
 
   seachForBars: function() {
+    
+    //Deletes the single event view
     this.$el.empty();
+    
+    //replaces with single event detailed view
     var data = this.model.toJSON()
     var compiledTemplate = this.singleEventTemplate(data);
     this.$el.append(compiledTemplate)

--- a/public/js/views/eventsView.js
+++ b/public/js/views/eventsView.js
@@ -4,13 +4,14 @@ App.Views.Events = Backbone.View.extend({
 
   initialize: function() {
     //console.log("Events collection view created");
-    this.listenTo(this.collection, "reset", this.renderOne);
-    this.listenTo(this.collection, "add", this.renderOne);
+    this.listenTo(this.collection, "reset", this.renderAll);
+    this.listenTo(this.collection, "add", this.renderAll);
     this.listenTo(this.collection, "add", this.searhForBars);
-    this.renderAll();
+    // this.renderAll();
   },
 
   renderAll: function() {
+    this.$el.empty();
     this.collection.each(this.renderOne, this);
   },
 


### PR DESCRIPTION
...collections on each search without removing the headers.  changed listeners for bar and events to run renderAll function instead of render one.  empty had to be in renderAll so it only happens once.
